### PR TITLE
fix: remove duplicate setting causing warning

### DIFF
--- a/license_manager/plugin.py
+++ b/license_manager/plugin.py
@@ -37,7 +37,6 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         # ("LICENSE_MANAGER_SECRET_KEY", "{{ 24|random_string }}"),
         ("LICENSE_MANAGER_DOCKER_IMAGE", "PLEASE-SET-ME"),
         ("LICENSE_MANAGER_MYSQL_PASSWORD", "{{ 8|random_string }}"),
-        ("LICENSE_MANAGER_OAUTH2_SECRET", "{{ 16|random_string }}"),
         ("LICENSE_MANAGER_SECRET_KEY", "{{ 24|random_string }}"),
         ("LICENSE_MANAGER_SOCIAL_AUTH_EDX_OAUTH2_SECRET", "{{ 16|random_string }}"),
         ("LICENSE_MANAGER_BACKEND_SERVICE_EDX_OAUTH2_SECRET", "{{ 16|random_string }}"),


### PR DESCRIPTION
**TL;DR -** Removes unnecessarily duplicated setting `LICENSE_MANAGER_OAUTH2_SECRET`

**Details**
when `tutor config save` is run, the following warning is printed:

    ⚠️  Found conflicting values for setting 'LICENSE_MANAGER_OAUTH2_SECRET': '{{ 16|random_string }}' or '{{ 16|random_string }}'`

The setting was duplicated in the same scope, so it was easy to find and remove.